### PR TITLE
Repo move: Replace adamamer20 with projectmesa

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ DataFrames are optimized for simultaneous operations through [SIMD processing](h
 
 The following is a performance graph showing execution time using mesa and mesa-frames for the [Boltzmann Wealth model](https://mesa.readthedocs.io/en/stable/tutorials/intro_tutorial.html).
 
-![Performance Graph with Mesa](https://github.com/adamamer20/mesa_frames/blob/main/examples/boltzmann_wealth/boltzmann_with_mesa.png)
+![Performance Graph with Mesa](https://github.com/projectmesa/mesa_frames/blob/main/examples/boltzmann_wealth/boltzmann_with_mesa.png)
 
-![Performance Graph without Mesa](https://github.com/adamamer20/mesa_frames/blob/main/examples/boltzmann_wealth/boltzmann_no_mesa.png)
+![Performance Graph without Mesa](https://github.com/projectmesa/mesa_frames/blob/main/examples/boltzmann_wealth/boltzmann_no_mesa.png)
 
-(The script used to generate the graph can be found [here](https://github.com/adamamer20/mesa_frames/blob/main/examples/boltzmann_wealth/performance_plot.py), but if you want to additionally compare vs Mesa, you have to uncomment `mesa_implementation` and its label)
+(The script used to generate the graph can be found [here](https://github.com/projectmesa/mesa_frames/blob/main/examples/boltzmann_wealth/performance_plot.py), but if you want to additionally compare vs Mesa, you have to uncomment `mesa_implementation` and its label)
 
 ## Installation
 
@@ -33,7 +33,7 @@ To install the most updated version of mesa-frames, you can clone the respositor
 To get started with mesa-frames, first clone the repository from GitHub:
 
 ```bash
-git clone https://github.com/adamamer20/mesa_frames.git
+git clone https://github.com/projectmesa/mesa_frames.git
 cd mesa_frames
 ```
 
@@ -159,4 +159,4 @@ mesa-frames is made available under the MIT License. This license allows you to 
 - The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 - The software is provided "as is", without warranty of any kind.
 
-For the full license text, see the [LICENSE](https://github.com/adamamer20/mesa_frames/blob/main/LICENSE) file in the GitHub repository.
+For the full license text, see the [LICENSE](https://github.com/projectmesa/mesa_frames/blob/main/LICENSE) file in the GitHub repository.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip install -e .
 
 **Note:** mesa-frames is currently in its early stages of development. As such, the usage patterns and API are subject to change. Breaking changes may be introduced. Reports of feedback and issues are encouraged.
 
-You can find the API documentation [here](https://adamamer20.github.io/mesa-frames/api).
+You can find the API documentation [here](https://projectmesa.github.io/mesa-frames/api).
 
 ### Creation of an Agent
 

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -56,7 +56,7 @@ autodoc_member_order = "bysource"
 autodoc_default_options = {"special-members": True, "exclude-members": "__weakref__"}
 
 # -- GitHub link and user guide settings -------------------------------------
-github_root = "https://github.com/adamamer20/mesa-frames"
+github_root = "https://github.com/projectmesa/mesa-frames"
 web_root = "https://adamamer20.github.io/mesa-frames"
 
 html_theme_options = {

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -57,7 +57,7 @@ autodoc_default_options = {"special-members": True, "exclude-members": "__weakre
 
 # -- GitHub link and user guide settings -------------------------------------
 github_root = "https://github.com/projectmesa/mesa-frames"
-web_root = "https://adamamer20.github.io/mesa-frames"
+web_root = "https://projectmesa.github.io/mesa-frames"
 
 html_theme_options = {
     "external_links": [

--- a/docs/general/index.md
+++ b/docs/general/index.md
@@ -15,9 +15,9 @@ DataFrames are optimized for simultaneous operations through [SIMD processing](h
 
 Check out our performance graphs comparing mesa and mesa-frames for the [Boltzmann Wealth model](https://mesa.readthedocs.io/en/stable/tutorials/intro_tutorial.html):
 
-![Performance Graph with Mesa](https://github.com/adamamer20/mesa-frames/raw/main/examples/boltzmann_wealth/boltzmann_with_mesa.png)
+![Performance Graph with Mesa](https://github.com/projectmesa/mesa-frames/raw/main/examples/boltzmann_wealth/boltzmann_with_mesa.png)
 
-![Performance Graph without Mesa](https://github.com/adamamer20/mesa-frames/raw/main/examples/boltzmann_wealth/boltzmann_no_mesa.png)
+![Performance Graph without Mesa](https://github.com/projectmesa/mesa-frames/raw/main/examples/boltzmann_wealth/boltzmann_no_mesa.png)
 
 ## Quick Start 🚀
 

--- a/docs/general/index.md
+++ b/docs/general/index.md
@@ -32,7 +32,7 @@ pip install mesa-frames
 #### Installing from Source
 
 ```bash
-git clone https://github.com/adamamer20/mesa_frames.git
+git clone https://github.com/projectmesa/mesa_frames.git
 cd mesa_frames
 pip install -e .
 ```
@@ -83,8 +83,8 @@ class MoneyModelDF(ModelDF):
 
 ## Get Involved! 🤝
 
-mesa-frames is in its early stages, and we welcome your feedback and contributions! Check out our [GitHub repository](https://github.com/adamamer20/mesa_frames) to get started.
+mesa-frames is in its early stages, and we welcome your feedback and contributions! Check out our [GitHub repository](https://github.com/projectmesa/mesa_frames) to get started.
 
 ## License
 
-mesa-frames is available under the MIT License. See the [LICENSE](https://github.com/adamamer20/mesa_frames/blob/main/LICENSE) file for full details.
+mesa-frames is available under the MIT License. See the [LICENSE](https://github.com/projectmesa/mesa_frames/blob/main/LICENSE) file for full details.

--- a/docs/general/user-guide/0_getting-started.md
+++ b/docs/general/user-guide/0_getting-started.md
@@ -87,7 +87,7 @@ Users can choose the backend that best suits their needs:
     ```
 
 Currently, there are two implementations of AgentSetDF and GridDF, one for each backend implementation: AgentSetPandas and AgentSetPolars, and GridPandas and GridPolars.
-We encourage you to use the Polars implementation for increased performance. We are working on creating a unique interface [here](https://github.com/adamamer20/mesa-frames/discussions/12). Let us know what you think!
+We encourage you to use the Polars implementation for increased performance. We are working on creating a unique interface [here](https://github.com/projectmesa/mesa-frames/discussions/12). Let us know what you think!
 
 Soon we will also have multiple other backends like Dask, cuDF, and Dask-cuDF!
 

--- a/docs/general/user-guide/4_benchmarks.md
+++ b/docs/general/user-guide/4_benchmarks.md
@@ -4,18 +4,18 @@ mesa-frames offers significant performance improvements over the original mesa f
 
 ## Boltzmann Wealth Model 💰
 
-[View the benchmark script](https://github.com/adamamer20/mesa-frames/blob/main/docs/scripts/readme_plot.py)
+[View the benchmark script](https://github.com/projectmesa/mesa-frames/blob/main/docs/scripts/readme_plot.py)
 
 ### Comparison with mesa
 
-![Performance Graph BW](https://github.com/adamamer20/mesa-frames/raw/main/docs/general/images/readme_plot_0.png)
+![Performance Graph BW](https://github.com/projectmesa/mesa-frames/raw/main/docs/general/images/readme_plot_0.png)
 
 ### Comparison of mesa-frames implementations
 
-![Performance Graph BW without Mesa](https://github.com/adamamer20/mesa-frames/raw/main/docs/general/images/readme_plot_1.png)
+![Performance Graph BW without Mesa](https://github.com/projectmesa/mesa-frames/raw/main/docs/general/images/readme_plot_1.png)
 
 ## SugarScape with Instantaneous Growback 🍬
 
-[View the benchmark script](https://github.com/adamamer20/mesa-frames/blob/main/examples/sugarscape_ig/performance_comparison.py)
+[View the benchmark script](https://github.com/projectmesa/mesa-frames/blob/main/examples/sugarscape_ig/performance_comparison.py)
 
-![Performance Graph SS IG](https://github.com/adamamer20/mesa-frames/raw/main/examples/benchmark_plot_0.png)
+![Performance Graph SS IG](https://github.com/projectmesa/mesa-frames/raw/main/examples/benchmark_plot_0.png)

--- a/mesa_frames/__init__.py
+++ b/mesa_frames/__init__.py
@@ -39,7 +39,7 @@ For more detailed information, refer to the full documentation and API reference
 
 Developed by: Adam Amer
 License: MIT
-GitHub: https://github.com/adamamer20/mesa_frames
+GitHub: https://github.com/projectmesa/mesa_frames
 """
 
 from mesa_frames.concrete.agents import AgentsDF

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Project information
 site_name: mesa-frames
-site_url: https://adamamer20.github.io/mesa-frames
+site_url: https://projectmesa.github.io/mesa-frames
 repo_url: https://github.com/projectmesa/mesa-frames
 repo_name: projectmesa/mesa-frames
 docs_dir: docs/general
@@ -73,7 +73,7 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.magiclink:
       repo_url_shorthand: true
-      user: adamamer20
+      user: projectmesa
       repo: mesa-frames
   - pymdownx.mark
   - pymdownx.smartsymbols
@@ -97,7 +97,7 @@ extra_javascript:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/adamamer20
+      link: https://github.com/projectmesa
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/mesa-frames/
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 # Project information
 site_name: mesa-frames
 site_url: https://adamamer20.github.io/mesa-frames
-repo_url: https://github.com/adamamer20/mesa-frames
-repo_name: adamamer20/mesa-frames
+repo_url: https://github.com/projectmesa/mesa-frames
+repo_name: projectmesa/mesa-frames
 docs_dir: docs/general
 
 # Theme configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dynamic = [
 
 [project.urls]
 Documentation = "https://adamamer20.github.io/mesa-frames"
-Repository = "https://github.com/adamamer20/mesa-frames.git"
+Repository = "https://github.com/projectmesa/mesa-frames.git"
 
 [project.optional-dependencies]
 mkdocs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dynamic = [
 
 
 [project.urls]
-Documentation = "https://adamamer20.github.io/mesa-frames"
+Documentation = "https://projectmesa.github.io/mesa-frames"
 Repository = "https://github.com/projectmesa/mesa-frames.git"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Replace adamamer20 with projectmesa 27 times across 8 files now that we moved the repository from adamamer20 to projectmesa.

This will probably both break and fix somethings, @adamamer20 could you check what needs to be updated by checking this diff?