### PR TITLE
Create release.yml file for automatic release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: ⚠️ Breaking changes
+      labels:
+        - breaking
+    - title: 🧪 Experimental features
+      labels:
+        - experimental
+    - title: 🎉 New features added
+      labels:
+        - feature
+    - title: 🛠 Enhancements made
+      labels:
+        - enhancement
+    - title: 🐛 Bugs fixed
+      labels:
+        - bug
+    - title: 📜 Documentation improvements
+      labels:
+        - docs
+    - title: 🔧 Maintenance
+      labels:
+        - ci
+        - testing
+        - dependency
+        - maintenance
+        - packaging
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Adds a configuration file `.github/release.yml` that lets GitHub automatically draft release notes based on the labels attached to PRs that will be included in that release. These drafted release notes can form a consistent basis for our changelog and manually expanded with context for certain PRs if needed.

The currently proposed labels are `experimental`, `breaking`, `feature`, `enhancement`, `bug`, `docs`, `ci`, `testing`, `dependency`, `maintenance` and `packaging`. The last five are grouped in the changelog under _Maintenance 🔧_.

For this to work nicely, it's important that all merged PRs have one of these labels attached to them and that the PR titles are sufficiently descriptive.

- See [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
- Examples of how this look can be found at the mesa repository [releases](https://github.com/projectmesa/mesa/releases).
- This configuration is identical to [the one](https://github.com/projectmesa/mesa/blob/002d3f4832bf83e6169aaa387f869f138ddb6874/.github/release.yml) at the main Mesa repo. See https://github.com/projectmesa/mesa/pull/1925.