### PR TITLE
Adding GH Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,67 +9,38 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report! 🙏
         Please provide as much detail as possible to help us address the issue.
-  - type: textarea
-    id: description
-    attributes:
-      label: 📝 Description
-      description: A clear and concise description of the bug
-      placeholder: When using the function X, I expected Y but got Z instead...
-    validations:
-      required: true
-  - type: textarea
-    id: steps
-    attributes:
-      label: 🔄 Steps to Reproduce
-      description: Provide a minimal code example that reproduces the error
-      value: |
+
+        Use the following suggested headers to structure your bug report.
+        Feel free to modify or add sections as needed to best communicate the issue.
+
+        ## 📝 Description
+        [Provide a clear and concise description of the bug]
+
+        ## 🔄 Steps to Reproduce
+        [Provide a minimal code example that reproduces the error]
         ```python
-        # Your code here (DO NOT REMOVE the ```python and ``` lines)
+        # Your code here
         ```
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: 🎯 Expected Behavior
-      description: What you expected to happen
-      placeholder: I expected the function to return...
-    validations:
-      required: true
-  - type: textarea
-    id: actual
-    attributes:
-      label: 🚨 Actual Behavior
-      description: What actually happened
-      placeholder: Instead, the function returned... / I got the following error...
-    validations:
-      required: true
-  - type: textarea
-    id: environment
-    attributes:
-      label: 🖥️ Environment Information
-      description: |
-        Please provide details about your environment.
-        Include Python version, OS, and relevant package versions.
-      value: |
+
+        ## 🎯 Expected Behavior
+        [What did you expect to happen?]
+
+        ## 🚨 Actual Behavior
+        [What actually happened? Include any error messages or unexpected output]
+
+        ## 🖥️ Environment Information
         Python version:
         Operating System:
-       
+        
         Relevant packages (output of `pip list` or the specific packages related to this issue):
         ```
         # Paste your pip list output or relevant package versions here
         ```
-    validations:
-      required: true
-  - type: textarea
-    id: logs
-    attributes:
-      label: 📊 Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
-  - type: textarea
-    id: additional
-    attributes:
-      label: ➕ Additional Context
-      description: Add any other context about the problem here
-      placeholder: Any other relevant information...
+
+        ## 📊 Relevant log output
+        ```
+        # Paste any relevant log output here
+        ```
+
+        ## ➕ Additional Context
+        [Add any other context about the problem here]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: File a bug report for mesa-frames
 title: "[Bug]: "
-labels: ["bug"]
+labels: ["triage", "bug"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,7 @@ body:
         [Provide a clear and concise description of the bug]
 
         ## 🔄 Steps to Reproduce
-        [Provide a minimal code example that reproduces the error]
+        [Provide a minimal code example that reproduces the error, see https://stackoverflow.com/help/minimal-reproducible-example]
         ```python
         # Your code here
         ```

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug Report
+description: File a bug report for mesa-frames
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        Please provide as much detail as possible to help us address the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug
+      placeholder: When using the function X, I expected Y but got Z instead...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Provide a minimal code example that reproduces the error
+      value: |
+        ```python
+        # Your code here (DO NOT REMOVE the ```python and ``` lines)
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+      placeholder: I expected the function to return...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+      placeholder: Instead, the function returned... / I got the following error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: |
+        Please provide details about your environment.
+        Include Python version, OS, and relevant package versions.
+      value: |
+        Python version: 
+        Operating System: 
+        
+        Relevant packages (output of `pip list` or the specific packages related to this issue):
+        ```
+        # Paste your pip list output or relevant package versions here
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here
+      placeholder: Any other relevant information...

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug Report
+name: 🐛 Bug Report
 description: File a bug report for mesa-frames
 title: "[Bug]: "
 labels: ["bug"]
@@ -7,22 +7,20 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
+        Thanks for taking the time to fill out this bug report! 🙏
         Please provide as much detail as possible to help us address the issue.
-
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: 📝 Description
       description: A clear and concise description of the bug
       placeholder: When using the function X, I expected Y but got Z instead...
     validations:
       required: true
-
   - type: textarea
     id: steps
     attributes:
-      label: Steps to Reproduce
+      label: 🔄 Steps to Reproduce
       description: Provide a minimal code example that reproduces the error
       value: |
         ```python
@@ -30,53 +28,48 @@ body:
         ```
     validations:
       required: true
-
   - type: textarea
     id: expected
     attributes:
-      label: Expected Behavior
+      label: 🎯 Expected Behavior
       description: What you expected to happen
       placeholder: I expected the function to return...
     validations:
       required: true
-
   - type: textarea
     id: actual
     attributes:
-      label: Actual Behavior
+      label: 🚨 Actual Behavior
       description: What actually happened
       placeholder: Instead, the function returned... / I got the following error...
     validations:
       required: true
-
   - type: textarea
     id: environment
     attributes:
-      label: Environment Information
+      label: 🖥️ Environment Information
       description: |
         Please provide details about your environment.
         Include Python version, OS, and relevant package versions.
       value: |
-        Python version: 
-        Operating System: 
-        
+        Python version:
+        Operating System:
+       
         Relevant packages (output of `pip list` or the specific packages related to this issue):
         ```
         # Paste your pip list output or relevant package versions here
         ```
     validations:
       required: true
-
   - type: textarea
     id: logs
     attributes:
-      label: Relevant log output
+      label: 📊 Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
-
   - type: textarea
     id: additional
     attributes:
-      label: Additional Context
+      label: ➕ Additional Context
       description: Add any other context about the problem here
       placeholder: Any other relevant information...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,42 +9,21 @@ body:
       value: |
         Thanks for taking the time to fill out this feature request! 🙏
         We appreciate your ideas to improve our project.
-  - type: textarea
-    id: problem
-    attributes:
-      label: 🤔 Is your feature request related to a problem? Please describe.
-      description: A clear and concise description of what the problem is.
-      placeholder: I'm always frustrated when [...]
-    validations:
-      required: true
-  - type: textarea
-    id: solution
-    attributes:
-      label: 💡 Describe the solution you'd like
-      description: A clear and concise description of what you want to happen.
-      placeholder: In this situation, I would like [...]
-    validations:
-      required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: 🔄 Describe alternatives you've considered
-      description: A clear and concise description of any alternative solutions or features you've considered.
-      placeholder: I have also thought about [...]
-  - type: dropdown
-    id: priority
-    attributes:
-      label: 🚀 Priority
-      description: How important is this feature to you?
-      options:
-        - 🟢 Low (Nice to have)
-        - 🟡 Medium (Important)
-        - 🔴 High (Critical)
-    validations:
-      required: true
-  - type: textarea
-    id: additional
-    attributes:
-      label: ➕ Additional context
-      description: Add any other context or screenshots about the feature request here.
-      placeholder: Any other relevant information...
+        
+        Please use the following suggested headers to structure your feature request.
+        Feel free to modify or add sections as needed to best communicate your idea.
+
+        ## 🤔 Problem Description
+        [Is your feature request related to a problem? Please provide a clear and concise description of what the problem is.]
+
+        ## 💡 Proposed Solution
+        [Describe the solution you'd like. What do you want to happen?]
+
+        ## 🔄 Alternatives Considered
+        [Have you considered any alternative solutions or features? If so, please describe them.]
+
+        ## 🚀 Priority
+        [How important is this feature to you? Low/Medium/High]
+
+        ## ➕ Additional Context
+        [Add any other context, screenshots, or examples about the feature request here.]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: ✨ Feature Request
 description: Suggest a feature for mesa-frames
 title: "[Feature]: "
 labels: ["feature"]
@@ -7,49 +7,44 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this feature request!
+        Thanks for taking the time to fill out this feature request! 🙏
         We appreciate your ideas to improve our project.
-
   - type: textarea
     id: problem
     attributes:
-      label: Is your feature request related to a problem? Please describe.
+      label: 🤔 Is your feature request related to a problem? Please describe.
       description: A clear and concise description of what the problem is.
       placeholder: I'm always frustrated when [...]
     validations:
       required: true
-
   - type: textarea
     id: solution
     attributes:
-      label: Describe the solution you'd like
+      label: 💡 Describe the solution you'd like
       description: A clear and concise description of what you want to happen.
       placeholder: In this situation, I would like [...]
     validations:
       required: true
-
   - type: textarea
     id: alternatives
     attributes:
-      label: Describe alternatives you've considered
+      label: 🔄 Describe alternatives you've considered
       description: A clear and concise description of any alternative solutions or features you've considered.
       placeholder: I have also thought about [...]
-
   - type: dropdown
     id: priority
     attributes:
-      label: Priority
+      label: 🚀 Priority
       description: How important is this feature to you?
       options:
-        - Low (Nice to have)
-        - Medium (Important)
-        - High (Critical)
+        - 🟢 Low (Nice to have)
+        - 🟡 Medium (Important)
+        - 🔴 High (Critical)
     validations:
       required: true
-
   - type: textarea
     id: additional
     attributes:
-      label: Additional context
+      label: ➕ Additional context
       description: Add any other context or screenshots about the feature request here.
       placeholder: Any other relevant information...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: ✨ Feature Request
 description: Suggest a feature for mesa-frames
 title: "[Feature]: "
-labels: ["feature"]
+labels: ["triage", "feature"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,8 +22,5 @@ body:
         ## 🔄 Alternatives Considered
         [Have you considered any alternative solutions or features? If so, please describe them.]
 
-        ## 🚀 Priority
-        [How important is this feature to you? Low/Medium/High]
-
         ## ➕ Additional Context
         [Add any other context, screenshots, or examples about the feature request here.]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a feature for mesa-frames
+title: "[Feature]: "
+labels: ["feature"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+        We appreciate your ideas to improve our project.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+      placeholder: In this situation, I would like [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+      placeholder: I have also thought about [...]
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Low (Nice to have)
+        - Medium (Important)
+        - High (Critical)
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+      placeholder: Any other relevant information...


### PR DESCRIPTION
This PR introduces standardized GitHub issue templates for bug reports and feature requests. These templates will help streamline our issue management process by ensuring that contributors provide consistent and comprehensive information when reporting bugs or suggesting new features.

1. Added a bug report template (`bug_report.yml`)
   - Includes fields for description, steps to reproduce, expected behavior, actual behavior, and environment information
   - Uses emojis for improved readability and user engagement

2. Added a feature request template (`feature_request.yml`)
   - Includes fields for problem description, proposed solution, alternatives considered, and priority
   - Also uses emojis for consistency and visual appeal

3. Both templates are configured to automatically add appropriate labels ("bug" or "feature" + "triage")