### PR TITLE
add sample joss paper

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,83 @@
+
+@article{Pearson:2017,
+	Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+	Adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170304627P},
+	Archiveprefix = {arXiv},
+	Author = {{Pearson}, S. and {Price-Whelan}, A.~M. and {Johnston}, K.~V.},
+	Eprint = {1703.04627},
+	Journal = {ArXiv e-prints},
+	Keywords = {Astrophysics - Astrophysics of Galaxies},
+	Month = mar,
+	Title = {{Gaps in Globular Cluster Streams: Pal 5 and the Galactic Bar}},
+	Year = 2017}
+
+@book{Binney:2008,
+	Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+	Adsurl = {http://adsabs.harvard.edu/abs/2008gady.book.....B},
+	Author = {{Binney}, J. and {Tremaine}, S.},
+	Booktitle = {Galactic Dynamics: Second Edition, by James Binney and Scott Tremaine.~ISBN 978-0-691-13026-2 (HB).~Published by Princeton University Press, Princeton, NJ USA, 2008.},
+	Publisher = {Princeton University Press},
+	Title = {{Galactic Dynamics: Second Edition}},
+	Year = 2008}
+
+@article{zenodo,
+	Abstractnote = {<p>Gala is a Python package for Galactic astronomy and gravitational dynamics. The bulk of the package centers around implementations of gravitational potentials, numerical integration, and nonlinear dynamics.</p>},
+	Author = {Adrian Price-Whelan and Brigitta Sipocz and Syrtis Major and Semyeong Oh},
+	Date-Modified = {2017-08-13 14:14:18 +0000},
+	Doi = {10.5281/zenodo.833339},
+	Month = {Jul},
+	Publisher = {Zenodo},
+	Title = {adrn/gala: v0.2.1},
+	Year = {2017},
+	Bdsk-Url-1 = {http://dx.doi.org/10.5281/zenodo.833339}}
+
+@ARTICLE{gaia,
+   author = {{Gaia Collaboration} and {Prusti}, T. and {de Bruijne}, J.~H.~J. and
+	{Brown}, A.~G.~A. and {Vallenari}, A. and {Babusiaux}, C. and
+	{Bailer-Jones}, C.~A.~L. and {Bastian}, U. and {Biermann}, M. and
+	{Evans}, D.~W. and et al.},
+    title = "{The Gaia mission}",
+  journal = {\aap},
+archivePrefix = "arXiv",
+   eprint = {1609.04153},
+ primaryClass = "astro-ph.IM",
+ keywords = {space vehicles: instruments, Galaxy: structure, astrometry, parallaxes, proper motions, telescopes},
+     year = 2016,
+    month = nov,
+   volume = 595,
+      eid = {A1},
+    pages = {A1},
+      doi = {10.1051/0004-6361/201629272},
+   adsurl = {http://adsabs.harvard.edu/abs/2016A%26A...595A...1G},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{astropy,
+   author = {{Astropy Collaboration} and {Robitaille}, T.~P. and {Tollerud}, E.~J. and
+	{Greenfield}, P. and {Droettboom}, M. and {Bray}, E. and {Aldcroft}, T. and
+	{Davis}, M. and {Ginsburg}, A. and {Price-Whelan}, A.~M. and
+	{Kerzendorf}, W.~E. and {Conley}, A. and {Crighton}, N. and
+	{Barbary}, K. and {Muna}, D. and {Ferguson}, H. and {Grollier}, F. and
+	{Parikh}, M.~M. and {Nair}, P.~H. and {Unther}, H.~M. and {Deil}, C. and
+	{Woillez}, J. and {Conseil}, S. and {Kramer}, R. and {Turner}, J.~E.~H. and
+	{Singer}, L. and {Fox}, R. and {Weaver}, B.~A. and {Zabalza}, V. and
+	{Edwards}, Z.~I. and {Azalee Bostroem}, K. and {Burke}, D.~J. and
+	{Casey}, A.~R. and {Crawford}, S.~M. and {Dencheva}, N. and
+	{Ely}, J. and {Jenness}, T. and {Labrie}, K. and {Lim}, P.~L. and
+	{Pierfederici}, F. and {Pontzen}, A. and {Ptak}, A. and {Refsdal}, B. and
+	{Servillat}, M. and {Streicher}, O.},
+    title = "{Astropy: A community Python package for astronomy}",
+  journal = {\aap},
+archivePrefix = "arXiv",
+   eprint = {1307.6212},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
+     year = 2013,
+    month = oct,
+   volume = 558,
+      eid = {A33},
+    pages = {A33},
+      doi = {10.1051/0004-6361/201322068},
+   adsurl = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,0 +1,120 @@
+---
+title: 'mesa-frames: an extension of mesa for performance and scalability'
+tags:
+  - Python
+  - Mesa
+  - Agent-Based Modeling
+  - Simulation
+  - Visualization
+authors:
+  - name: Author With ORCID
+    orcid: 0000-0000-0000-0000
+    equal-contrib: true
+    affiliation: "1, 2" # (Multiple affiliations must be quoted)
+  - name: Author Without ORCID
+    equal-contrib: true # (This is how you can denote equal contributions between multiple authors)
+    affiliation: 2
+  - name: Author with no affiliation
+    corresponding: true # (This is how to denote the corresponding author)
+    affiliation: 3
+  - given-names: LudwigAuthor with affiliation
+    dropping-particle: van
+    surname: Surname
+    affiliation: 3
+affiliations:
+ - name: Affiliation 1
+   index: 1
+   ror: 00hx57361
+ - name: Institution Name, Country
+   index: 2
+ - name: Independent Researcher, Country
+   index: 3
+date: 13 August 2017
+bibliography: paper.bib
+
+# Optional fields if submitting to a AAS journal too, see this blog post:
+# https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
+aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
+aas-journal: Astrophysical Journal <- The name of the AAS journal.
+---
+
+# Summary
+
+The forces on stars, galaxies, and dark matter under external gravitational
+fields lead to the dynamical evolution of structures in the universe. The orbits
+of these bodies are therefore key to understanding the formation, history, and
+future state of galaxies. The field of "galactic dynamics," which aims to model
+the gravitating components of galaxies to study their structure and evolution,
+is now well-established, commonly taught, and frequently used in astronomy.
+Aside from toy problems and demonstrations, the majority of problems require
+efficient numerical tools, many of which require the same base code (e.g., for
+performing numerical orbit integration).
+
+# Statement of need
+
+`Gala` is an Astropy-affiliated Python package for galactic dynamics. Python
+enables wrapping low-level languages (e.g., C) for speed without losing
+flexibility or ease-of-use in the user-interface. The API for `Gala` was
+designed to provide a class-based and user-friendly interface to fast (C or
+Cython-optimized) implementations of common operations such as gravitational
+potential and force evaluation, orbit integration, dynamical transformations,
+and chaos indicators for nonlinear dynamics. `Gala` also relies heavily on and
+interfaces well with the implementations of physical units and astronomical
+coordinate systems in the `Astropy` package [@astropy] (`astropy.units` and
+`astropy.coordinates`).
+
+`Gala` was designed to be used by both astronomical researchers and by
+students in courses on gravitational dynamics or astronomy. It has already been
+used in a number of scientific publications [@Pearson:2017] and has also been
+used in graduate courses on Galactic dynamics to, e.g., provide interactive
+visualizations of textbook material [@Binney:2008]. The combination of speed,
+design, and support for Astropy functionality in `Gala` will enable exciting
+scientific explorations of forthcoming data releases from the *Gaia* mission
+[@gaia] by students and experts alike.
+
+# Mathematics
+
+Single dollars ($) are required for inline mathematics e.g. $f(x) = e^{\pi/x}$
+
+Double dollars make self-standing equations:
+
+$$\Theta(x) = \left\{\begin{array}{l}
+0\textrm{ if } x < 0\cr
+1\textrm{ else}
+\end{array}\right.$$
+
+You can also use plain \LaTeX for equations
+\begin{equation}\label{eq:fourier}
+\hat f(\omega) = \int_{-\infty}^{\infty} f(x) e^{i\omega x} dx
+\end{equation}
+and refer to \autoref{eq:fourier} from text.
+
+# Citations
+
+Citations to entries in paper.bib should be in
+[rMarkdown](http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html)
+format.
+
+If you want to cite a software repository URL (e.g. something on GitHub without a preferred
+citation) then you can do it with the example BibTeX entry below for @fidgit.
+
+For a quick reference, the following citation commands can be used:
+- `@author:2001`  ->  "Author et al. (2001)"
+- `[@author:2001]` -> "(Author et al., 2001)"
+- `[@author1:2001; @author2:2001]` -> "(Author1 et al., 2001; Author2 et al., 2002)"
+
+# Figures
+
+Figures can be included like this:
+![Caption for example figure.\label{fig:example}](figure.png)
+and referenced from text using \autoref{fig:example}.
+
+Figure sizes can be customized by adding an optional second parameter:
+![Caption for example figure.](figure.png){ width=20% }
+
+# Acknowledgements
+
+We acknowledge contributions from Brigitta Sipocz, Syrtis Major, and Semyeong
+Oh, and support from Kathryn Johnston during the genesis of this project.
+
+# References


### PR DESCRIPTION
This is a first step for #90, using an example paper from JOSS: https://joss.readthedocs.io/en/latest/example_paper.html.

To build a pdf locally (assuming `pandoc` is installed with necessary dependencies):

```bash
cd paper/
pandoc --citeproc paper.md -o paper.pdf
```

JOSS uses a latex template but I couldn't get it working on my machine, so the resulting `paper.pdf` doesn't look the same as what JOSS produces. Nonetheless, this helps make sure that there isn't any compile error when generating the pdf.