### PR TITLE
Ensure Unique unique_id Values When Adding Agents to AgentSetPolars

### DIFF
--- a/mesa_frames/concrete/polars/agentset.py
+++ b/mesa_frames/concrete/polars/agentset.py
@@ -136,7 +136,6 @@ class AgentSetPolars(AgentSetDF, PolarsMixin):
 
         if new_agents["unique_id"].dtype != pl.Int64:
             raise TypeError("unique_id column must be of type int64.")
-        
 
         # If self._mask is pl.Expr, then new mask is the same.
         # If self._mask is pl.Series[bool], then new mask has to be updated.
@@ -144,12 +143,10 @@ class AgentSetPolars(AgentSetDF, PolarsMixin):
         if isinstance(obj._mask, pl.Series):
             original_active_indices = obj._agents.filter(obj._mask)["unique_id"]
 
-        
-
-        combined_agents= pl.concat([obj._agents, new_agents], how="diagonal_relaxed")
+        combined_agents = pl.concat([obj._agents, new_agents], how="diagonal_relaxed")
         if combined_agents["unique_id"].is_duplicated().any():
             raise ValueError(
-                "Some ids are duplicated in the AgentSet that are trying to be added."
+                "Some ids are duplicated in the AgentSet that are trying to be added together."
             )
 
         obj._agents = combined_agents

--- a/tests/polars/test_agentset_polars.py
+++ b/tests/polars/test_agentset_polars.py
@@ -92,7 +92,7 @@ class Test_AgentSetPolars:
 
         with pytest.raises(
             ValueError,
-            match="Some ids are duplicated in the AgentSet that are trying to be added.",
+            match="Some ids are duplicated in the AgentSet that are trying to be added together.",
         ):
             result = agents.add(agents4.agents, inplace=False)
 

--- a/tests/polars/test_agentset_polars.py
+++ b/tests/polars/test_agentset_polars.py
@@ -33,6 +33,17 @@ def fix1_AgentSetPolars() -> ExampleAgentSetPolars:
 
 
 @pytest.fixture
+def fix4_AgentSetPolars() -> ExampleAgentSetPolars:
+    model = ModelDF()
+    agents = ExampleAgentSetPolars(model)
+    agents.add({"unique_id": [0, 1, 2, 3]})
+    agents["wealth"] = agents.starting_wealth
+    agents["age"] = [10, 20, 30, 40]
+    model.agents.add(agents)
+    return agents
+
+
+@pytest.fixture
 def fix2_AgentSetPolars() -> ExampleAgentSetPolars:
     model = ModelDF()
     agents = ExampleAgentSetPolars(model)
@@ -73,9 +84,17 @@ class Test_AgentSetPolars:
         self,
         fix1_AgentSetPolars: ExampleAgentSetPolars,
         fix2_AgentSetPolars: ExampleAgentSetPolars,
+        fix4_AgentSetPolars: ExampleAgentSetPolars,
     ):
         agents = fix1_AgentSetPolars
         agents2 = fix2_AgentSetPolars
+        agents4 = fix4_AgentSetPolars
+
+        with pytest.raises(
+            ValueError,
+            match="Some ids are duplicated in the AgentSet that are trying to be added.",
+        ):
+            result = agents.add(agents4.agents, inplace=False)
 
         # Test with a DataFrame
         result = agents.add(agents2.agents, inplace=False)


### PR DESCRIPTION
Adds a check to prevent duplicate `unique_id` values when adding agents to `AgentSetPolars`.