### PR TITLE
chore: Update pyproject.toml to use PEP 735 dependency groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ name: build
 on:
   push:
     branches:
-    - main
-    - release**
+      - main
+      - release**
     paths-ignore:
       - '**.md'
   pull_request:
@@ -24,40 +24,43 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.os }}-latest
-    # We need an explicit timeout because sometimes the batch_runner test never
-    # completes.
     timeout-minutes: 6
+
     strategy:
-      fail-fast: False
+      fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
-        python-version: ["3.13"]
+        python-version: ['3.13']
         include:
           - os: ubuntu
-            python-version: "3.11"
+            python-version: '3.11'
           - os: ubuntu
-            python-version: "3.12"
-          # Disabled for now. See https://github.com/projectmesa/mesa/issues/1253
-          #- os: ubuntu
-          #  python-version: 'pypy-3.8'
+            python-version: '3.12'
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install uv
-      run: pip install uv
-    - name: Install mesa-frames
-      # See https://github.com/astral-sh/uv/issues/1945
-      run: |
-        uv pip install --system .[dev]
-    - name: Test with pytest
-      run: pytest --durations=10 --cov=mesa_frames tests/ --cov-report=xml
-    - if: matrix.os == 'ubuntu'
-      name: Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install uv via GitHub Action
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install mesa-frames + dev dependencies
+        run: |
+          # 1. Install the project itself
+          uv pip install --system .
+          # 2. Install everything under the "dev" dependency group
+          uv pip install --group dev --system
+
+      - name: Test with pytest
+        run: pytest --durations=10 --cov=mesa_frames tests/ --cov-report=xml
+
+      - if: matrix.os == 'ubuntu'
+        name: Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,107 +1,130 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Build system (unchanged)
+# ──────────────────────────────────────────────────────────────────────────────
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires       = ["hatchling"]
+build-backend  = "hatchling.build"
 
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Project metadata (updated dependency versions)
+# ──────────────────────────────────────────────────────────────────────────────
 [project]
-name = "mesa_frames"
-description = "An extension to the Mesa framework which uses Polars DataFrames for enhanced performance"
-authors = [
+name            = "mesa_frames"
+description     = "An extension to the Mesa framework which uses Polars DataFrames for enhanced performance"
+authors         = [
   { name = "Project Mesa Team", email = "projectmesa@googlegroups.com" },
-  { name = "Adam Amer"},
+  { name = "Adam Amer" },
 ]
-license = { text = "MIT" }
-readme = "README.md"
-keywords = [
-    "simulation",
-    "simulation-environment",
-    "gis",
-    "simulation-framework",
-    "agent-based-modeling",
-    "complex-systems",
-    "spatial-models",
-    "mesa",
-    "complexity-analysis",
-    "modeling-agents",
-    "agent-based-modelling"
+license         = { text = "MIT" }
+readme          = "README.md"
+keywords        = [
+  "simulation", "simulation-environment", "gis", "simulation-framework",
+  "agent-based-modeling", "complex-systems", "spatial-models", "mesa",
+  "complexity-analysis", "modeling-agents", "agent-based-modelling",
 ]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Topic :: Scientific/Engineering :: Artificial Life",
-]
-dependencies = [
-  "numpy>=2.0.2",
-  "pyarrow",
-  ## polars
-  "polars>=1.0.0", #polars._typing (see mesa_frames.types) added in 1.0.0
-  #"geopolars" (currently in pre-alpha)
+classifiers     = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Topic :: Scientific/Engineering :: Artificial Life",
 ]
 requires-python = ">=3.11"
-dynamic = [
-  "version"
+dependencies    = [
+  "numpy>=2.0.2",
+  "pyarrow>=20.0.0",
+  # polars._typing added in 1.0.0
+  "polars>=1.30.0",
 ]
-
-
+dynamic         = ["version"]
 
 [project.urls]
 Documentation = "https://projectmesa.github.io/mesa-frames"
-Repository = "https://github.com/projectmesa/mesa-frames.git"
+Repository    = "https://github.com/projectmesa/mesa-frames.git"
 
-[project.optional-dependencies]
-mkdocs = [
-  "mkdocs-material",
-  "mkdocs-jupyter",
-  "mkdocs-git-revision-date-localized-plugin",
-  "mkdocs-minify-plugin",
-  "mkdocs-include-markdown-plugin"
-]
 
-sphinx = [
-  "sphinx",
-  "sphinx-rtd-theme",
-  "numpydoc",
-  "pydata-sphinx-theme",
-  "sphinx-copybutton",
-  "sphinx-design",
-  "autodocsumm"
+# ──────────────────────────────────────────────────────────────────────────────
+# Dependency groups (PEP 735) – local-only, never shipped to PyPI
+# ──────────────────────────────────────────────────────────────────────────────
+[dependency-groups]
+
+test = [
+  "pytest>=8.3.5",
+  "pytest-cov>=6.1.1",
+  "beartype>=0.21.0",
 ]
 
 docs = [
-  "mesa_frames[mkdocs, sphinx]",
-  # Readme Script
-  "perfplot",
-  "seaborn"
+  "mkdocs-material>=9.6.14",
+  "mkdocs-jupyter>=0.25.1",
+  "mkdocs-git-revision-date-localized-plugin>=1.4.7",
+  "mkdocs-minify-plugin>=0.8.0",
+  "mkdocs-include-markdown-plugin>=7.1.5",
+  "sphinx>=7.4.7",
+  "sphinx-rtd-theme>=3.0.2",
+  "numpydoc>=1.8.0",
+  "pydata-sphinx-theme>=0.16.1",
+  "sphinx-copybutton>=0.5.2",
+  "sphinx-design>=0.6.1",
+  "autodocsumm>=0.2.14",
+  "perfplot>=0.10.2",
+  "seaborn>=0.13.2",
 ]
 
-test = [
-  "pytest",
-  "pytest-cov",
-  "beartype",
-]
-
+# dev = test ∪ docs ∪ extra tooling
 dev = [
-  "mesa_frames[test, docs]",
+  { include-group = "test" },
+  { include-group = "docs" },
   "mesa~=2.3.4",
-  "numba>=0.60",
+  "numba>=0.60.0",
   "ruff>=0.11.12",
   "pre-commit>=4.2.0",
 ]
 
-[tool.hatch.envs.test]
-features = ["test"]
 
-[tool.hatch.envs.dev] #Allows installing dev as virtual env
-features = ["dev"]
-env = { MESA_FRAMES_RUNTIME_TYPECHECKING = "true" }
-
-[tool.hatch.build.targets.wheel]
-packages = ["mesa_frames"]
-
+# ──────────────────────────────────────────────────────────────────────────────
+# Hatch configuration
+# ──────────────────────────────────────────────────────────────────────────────
 [tool.hatch.version]
 path = "mesa_frames/__init__.py"
 
+# Ask Hatch to use uv as the installer everywhere for speed.
+[tool.hatch.envs.default]
+installer = "uv"
+
+# Testing environment ‒ installs ONLY the "test" group
+[tool.hatch.envs.test]
+dependencies = [{ include-group = "test" }]
+
+# Docs build environment
+[tool.hatch.envs.docs]
+dependencies = [{ include-group = "docs" }]
+
+# Dev environment (inherits uv installer)
+[tool.hatch.envs.dev]
+dependencies = [{ include-group = "dev" }]
+env = { MESA_FRAMES_RUNTIME_TYPECHECKING = "true" }
+
+# Wheel build – unchanged
+[tool.hatch.build.targets.wheel]
+packages = ["mesa_frames"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# uv configuration
+# ──────────────────────────────────────────────────────────────────────────────
+[tool.uv]
+# Install the dev stack by default when you run `uv sync`
+default-groups = ["dev"]
+
+[tool.uv.sources]
+mesa-frames = { workspace = true }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Ruff linter – unchanged
+# ──────────────────────────────────────────────────────────────────────────────
 [tool.ruff.lint]
 select = ["D"]
 ignore = ["D101", "D102", "D105"]
@@ -110,15 +133,6 @@ ignore = ["D101", "D102", "D105"]
 convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["D"]
+"tests/*"    = ["D"]
 "examples/*" = ["D"]
-"docs/*" = ["D"]
-
-[tool.uv.sources]
-mesa-frames = { workspace = true }
-
-[dependency-groups]
-dev = [
-    "mesa-frames[dev]",
-]
-
+"docs/*"     = ["D"]

--- a/uv.lock
+++ b/uv.lock
@@ -1198,7 +1198,7 @@ dependencies = [
     { name = "pyarrow" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "autodocsumm" },
     { name = "beartype" },
@@ -1238,92 +1238,64 @@ docs = [
     { name = "sphinx-design" },
     { name = "sphinx-rtd-theme" },
 ]
-mkdocs = [
-    { name = "mkdocs-git-revision-date-localized-plugin" },
-    { name = "mkdocs-include-markdown-plugin" },
-    { name = "mkdocs-jupyter" },
-    { name = "mkdocs-material" },
-    { name = "mkdocs-minify-plugin" },
-]
-sphinx = [
-    { name = "autodocsumm" },
-    { name = "numpydoc" },
-    { name = "pydata-sphinx-theme" },
-    { name = "sphinx" },
-    { name = "sphinx-copybutton" },
-    { name = "sphinx-design" },
-    { name = "sphinx-rtd-theme" },
-]
 test = [
     { name = "beartype" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "mesa-frames", extra = ["dev"] },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "autodocsumm", marker = "extra == 'dev'" },
-    { name = "autodocsumm", marker = "extra == 'docs'" },
-    { name = "autodocsumm", marker = "extra == 'sphinx'" },
-    { name = "beartype", marker = "extra == 'dev'" },
-    { name = "beartype", marker = "extra == 'test'" },
-    { name = "mesa", marker = "extra == 'dev'", specifier = "~=2.3.4" },
-    { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'dev'" },
-    { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'docs'" },
-    { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'mkdocs'" },
-    { name = "mkdocs-include-markdown-plugin", marker = "extra == 'dev'" },
-    { name = "mkdocs-include-markdown-plugin", marker = "extra == 'docs'" },
-    { name = "mkdocs-include-markdown-plugin", marker = "extra == 'mkdocs'" },
-    { name = "mkdocs-jupyter", marker = "extra == 'dev'" },
-    { name = "mkdocs-jupyter", marker = "extra == 'docs'" },
-    { name = "mkdocs-jupyter", marker = "extra == 'mkdocs'" },
-    { name = "mkdocs-material", marker = "extra == 'dev'" },
-    { name = "mkdocs-material", marker = "extra == 'docs'" },
-    { name = "mkdocs-material", marker = "extra == 'mkdocs'" },
-    { name = "mkdocs-minify-plugin", marker = "extra == 'dev'" },
-    { name = "mkdocs-minify-plugin", marker = "extra == 'docs'" },
-    { name = "mkdocs-minify-plugin", marker = "extra == 'mkdocs'" },
-    { name = "numba", marker = "extra == 'dev'", specifier = ">=0.60" },
     { name = "numpy", specifier = ">=2.0.2" },
-    { name = "numpydoc", marker = "extra == 'dev'" },
-    { name = "numpydoc", marker = "extra == 'docs'" },
-    { name = "numpydoc", marker = "extra == 'sphinx'" },
-    { name = "perfplot", marker = "extra == 'dev'" },
-    { name = "perfplot", marker = "extra == 'docs'" },
-    { name = "polars", specifier = ">=1.0.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
-    { name = "pyarrow" },
-    { name = "pydata-sphinx-theme", marker = "extra == 'dev'" },
-    { name = "pydata-sphinx-theme", marker = "extra == 'docs'" },
-    { name = "pydata-sphinx-theme", marker = "extra == 'sphinx'" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'test'" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "pytest-cov", marker = "extra == 'test'" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.12" },
-    { name = "seaborn", marker = "extra == 'dev'" },
-    { name = "seaborn", marker = "extra == 'docs'" },
-    { name = "sphinx", marker = "extra == 'dev'" },
-    { name = "sphinx", marker = "extra == 'docs'" },
-    { name = "sphinx", marker = "extra == 'sphinx'" },
-    { name = "sphinx-copybutton", marker = "extra == 'dev'" },
-    { name = "sphinx-copybutton", marker = "extra == 'docs'" },
-    { name = "sphinx-copybutton", marker = "extra == 'sphinx'" },
-    { name = "sphinx-design", marker = "extra == 'dev'" },
-    { name = "sphinx-design", marker = "extra == 'docs'" },
-    { name = "sphinx-design", marker = "extra == 'sphinx'" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'dev'" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'sphinx'" },
+    { name = "polars", specifier = ">=1.30.0" },
+    { name = "pyarrow", specifier = ">=20.0.0" },
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "mesa-frames", extras = ["dev"], editable = "." }]
+dev = [
+    { name = "autodocsumm", specifier = ">=0.2.14" },
+    { name = "beartype", specifier = ">=0.21.0" },
+    { name = "mesa", specifier = "~=2.3.4" },
+    { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.7" },
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
+    { name = "mkdocs-jupyter", specifier = ">=0.25.1" },
+    { name = "mkdocs-material", specifier = ">=9.6.14" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
+    { name = "numba", specifier = ">=0.60.0" },
+    { name = "numpydoc", specifier = ">=1.8.0" },
+    { name = "perfplot", specifier = ">=0.10.2" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pydata-sphinx-theme", specifier = ">=0.16.1" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "ruff", specifier = ">=0.11.12" },
+    { name = "seaborn", specifier = ">=0.13.2" },
+    { name = "sphinx", specifier = ">=7.4.7" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "sphinx-design", specifier = ">=0.6.1" },
+    { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
+]
+docs = [
+    { name = "autodocsumm", specifier = ">=0.2.14" },
+    { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.7" },
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
+    { name = "mkdocs-jupyter", specifier = ">=0.25.1" },
+    { name = "mkdocs-material", specifier = ">=9.6.14" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
+    { name = "numpydoc", specifier = ">=1.8.0" },
+    { name = "perfplot", specifier = ">=0.10.2" },
+    { name = "pydata-sphinx-theme", specifier = ">=0.16.1" },
+    { name = "seaborn", specifier = ">=0.13.2" },
+    { name = "sphinx", specifier = ">=7.4.7" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "sphinx-design", specifier = ">=0.6.1" },
+    { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
+]
+test = [
+    { name = "beartype", specifier = ">=0.21.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+]
 
 [[package]]
 name = "mesa-viz-tornado"


### PR DESCRIPTION
This pull request introduces several updates to the build workflow and project configuration, focusing on improving dependency management, streamlining the build process, and ensuring compatibility with updated tools. The most significant changes include enhancements to the GitHub Actions workflow, updates to dependency versions in `pyproject.toml`, and restructuring of optional dependency groups.

### Build Workflow Improvements:
* Updated the GitHub Actions workflow in `.github/workflows/build.yml` to use the `astral-sh/setup-uv` action for installing `uv`, and restructured installation steps for better clarity and maintainability.
* Enabled the `fail-fast` strategy in the matrix configuration and standardized the use of single quotes for Python version strings.

### Dependency Updates:
* Updated dependency versions in `pyproject.toml`, including `polars` (from `>=1.0.0` to `>=1.30.0`), `pyarrow` (to `>=20.0.0`), and others in the `test`, `docs`, and `dev` groups.
* Added `requires-python = ">=3.11"` to ensure compatibility with Python 3.11 and later.

### Dependency Group Restructuring:
* Reorganized optional dependency groups in `pyproject.toml` (e.g., `test`, `docs`, `dev`) to follow PEP 735 standards, improving clarity and maintainability. Groups now include explicit version constraints and references to other groups where applicable.

### Hatch and `uv` Configuration:
* Introduced a `tool.hatch.envs` section in `pyproject.toml` to define environments for testing, documentation, and development. Added a `tool.uv` section to configure `uv` as the default installer for speed and efficiency.

### Minor Formatting Changes:
* Reformatted the `keywords` array in `pyproject.toml` for better readability by consolidating entries into a single line.Enhance project metadata in `pyproject.toml` and `uv.lock` by updating dependency versions and improving version specifications for better compatibility and performance.