### PR TITLE
Ehancement: Add names to `AgentSetDF` and `AgentSetsAccessor` for name/type/index lookup and container-aware keying 

### DIFF
--- a/mesa_frames/abstract/accessors.py
+++ b/mesa_frames/abstract/accessors.py
@@ -8,7 +8,7 @@ from mesa_frames.abstract.agents import AgentSetDF
 from mesa_frames.types_ import KeyBy
 
 
-class AgentSetsAccessorBase(ABC):
+class AbstractAgentSetsAccessor(ABC):
     """Abstract accessor for collections of agent sets.
 
     This interface defines a flexible, user-friendly API to access agent sets
@@ -42,7 +42,9 @@ class AgentSetsAccessorBase(ABC):
     """
 
     @abstractmethod
-    def __getitem__(self, key: int | str | type[AgentSetDF]) -> AgentSetDF | list[AgentSetDF]:
+    def __getitem__(
+        self, key: int | str | type[AgentSetDF]
+    ) -> AgentSetDF | list[AgentSetDF]:
         """Retrieve agent set(s) by index, name, or type.
 
         Parameters

--- a/mesa_frames/abstract/accessors.py
+++ b/mesa_frames/abstract/accessors.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any
+
+from mesa_frames.abstract.agents import AgentSetDF
+from mesa_frames.types_ import KeyBy
+
+
+class AgentSetsAccessorBase(ABC):
+    """Abstract accessor for collections of agent sets.
+
+    This interface defines a flexible, user-friendly API to access agent sets
+    by name, positional index, or class/type, and to iterate or view the
+    collection under different key domains.
+
+    Notes
+    -----
+    Concrete implementations should:
+    - Support ``__getitem__`` with ``int`` | ``str`` | ``type[AgentSetDF]``.
+    - Return a list for type-based queries (even when there is one match).
+    - Provide keyed iteration via ``keys/items/iter/mapping`` with ``key_by``.
+    - Expose read-only snapshots ``by_name`` and ``by_type``.
+
+    Examples
+    --------
+    Assuming ``agents`` is an :class:`~mesa_frames.concrete.agents.AgentsDF`:
+
+    >>> sheep = agents.sets["Sheep"]             # name lookup
+    >>> first = agents.sets[0]                    # index lookup
+    >>> wolves = agents.sets[Wolf]                # type lookup → list
+    >>> len(wolves) >= 0
+    True
+
+    Choose a key view when iterating:
+
+    >>> for k, aset in agents.sets.items(key_by="index"):
+    ...     print(k, aset.name)
+    0 Sheep
+    1 Wolf
+    """
+
+    @abstractmethod
+    def __getitem__(self, key: int | str | type[AgentSetDF]) -> AgentSetDF | list[AgentSetDF]:
+        """Retrieve agent set(s) by index, name, or type.
+
+        Parameters
+        ----------
+        key : int | str | type[AgentSetDF]
+            - ``int``: positional index (supports negative indices).
+            - ``str``: agent set name.
+            - ``type``: class or subclass of :class:`AgentSetDF`.
+
+        Returns
+        -------
+        AgentSetDF | list[AgentSetDF]
+            A single agent set for ``int``/``str`` keys; a list of matching
+            agent sets for ``type`` keys (possibly empty).
+
+        Raises
+        ------
+        IndexError
+            If an index is out of range.
+        KeyError
+            If a name is missing.
+        TypeError
+            If the key type is unsupported.
+        """
+
+    @abstractmethod
+    def get(self, key: int | str | type[AgentSetDF], default: Any | None = None) -> Any:
+        """Safe lookup variant that returns a default on miss.
+
+        Parameters
+        ----------
+        key : int | str | type[AgentSetDF]
+            Lookup key; see :meth:`__getitem__`.
+        default : Any, optional
+            Value to return when the lookup fails. If ``key`` is a type and no
+            matches are found, implementers may prefer returning ``[]`` when
+            ``default`` is ``None`` to keep list shape stable.
+
+        Returns
+        -------
+        Any
+            The resolved value or ``default``.
+        """
+
+    @abstractmethod
+    def first(self, t: type[AgentSetDF]) -> AgentSetDF:
+        """Return the first agent set matching a type.
+
+        Parameters
+        ----------
+        t : type[AgentSetDF]
+            The concrete class (or base class) to match.
+
+        Returns
+        -------
+        AgentSetDF
+            The first matching agent set in iteration order.
+
+        Raises
+        ------
+        KeyError
+            If no agent set matches ``t``.
+
+        Examples
+        --------
+        >>> agents.sets.first(Wolf)  # doctest: +SKIP
+        <Wolf ...>
+        """
+
+    @abstractmethod
+    def all(self, t: type[AgentSetDF]) -> list[AgentSetDF]:
+        """Return all agent sets matching a type.
+
+        Parameters
+        ----------
+        t : type[AgentSetDF]
+            The concrete class (or base class) to match.
+
+        Returns
+        -------
+        list[AgentSetDF]
+            A list of all matching agent sets (possibly empty).
+
+        Examples
+        --------
+        >>> agents.sets.all(Wolf)  # doctest: +SKIP
+        [<Wolf ...>, <Wolf ...>]
+        """
+
+    @abstractmethod
+    def at(self, index: int) -> AgentSetDF:
+        """Return the agent set at a positional index.
+
+        Parameters
+        ----------
+        index : int
+            Positional index; negative indices are supported.
+
+        Returns
+        -------
+        AgentSetDF
+            The agent set at the given position.
+
+        Raises
+        ------
+        IndexError
+            If ``index`` is out of range.
+
+        Examples
+        --------
+        >>> agents.sets.at(0) is agents.sets[0]
+        True
+        """
+
+    @abstractmethod
+    def keys(self, *, key_by: KeyBy = "name") -> Iterable[Any]:
+        """Iterate keys under a chosen key domain.
+
+        Parameters
+        ----------
+        key_by : {"name", "index", "object", "type"}, default "name"
+            - ``"name"`` → agent set names.
+            - ``"index"`` → positional indices.
+            - ``"object"`` → the :class:`AgentSetDF` objects.
+            - ``"type"`` → the concrete classes of each set.
+
+        Returns
+        -------
+        Iterable[Any]
+            An iterable of keys corresponding to the selected domain.
+        """
+
+    @abstractmethod
+    def items(self, *, key_by: KeyBy = "name") -> Iterable[tuple[Any, AgentSetDF]]:
+        """Iterate ``(key, AgentSetDF)`` pairs under a chosen key domain.
+
+        See :meth:`keys` for the meaning of ``key_by``.
+        """
+
+    @abstractmethod
+    def values(self) -> Iterable[AgentSetDF]:
+        """Iterate over agent set values only (no keys)."""
+
+    @abstractmethod
+    def iter(self, *, key_by: KeyBy = "name") -> Iterable[tuple[Any, AgentSetDF]]:
+        """Alias for :meth:`items` for convenience."""
+
+    @abstractmethod
+    def mapping(self, *, key_by: KeyBy = "name") -> dict[Any, AgentSetDF]:
+        """Return a dictionary view keyed by the chosen domain.
+
+        Notes
+        -----
+        ``key_by="type"`` will keep the last set per type. For one-to-many
+        grouping, prefer the read-only :attr:`by_type` snapshot.
+        """
+
+    @property
+    @abstractmethod
+    def by_name(self) -> Mapping[str, AgentSetDF]:
+        """Read-only mapping of names to agent sets.
+
+        Returns
+        -------
+        Mapping[str, AgentSetDF]
+            An immutable snapshot that maps each agent set name to its object.
+
+        Notes
+        -----
+        Implementations should return a read-only mapping such as
+        ``types.MappingProxyType`` over an internal dict to avoid accidental
+        mutation.
+
+        Examples
+        --------
+        >>> sheep = agents.sets.by_name["Sheep"]  # doctest: +SKIP
+        >>> sheep is agents.sets["Sheep"]  # doctest: +SKIP
+        True
+        """
+
+    @property
+    @abstractmethod
+    def by_type(self) -> Mapping[type, list[AgentSetDF]]:
+        """Read-only mapping of types to lists of agent sets.
+
+        Returns
+        -------
+        Mapping[type, list[AgentSetDF]]
+            An immutable snapshot grouping agent sets by their concrete class.
+
+        Notes
+        -----
+        This supports one-to-many relationships where multiple sets share the
+        same type. Prefer this over ``mapping(key_by="type")`` when you need
+        grouping instead of last-write-wins semantics.
+        """
+
+    @abstractmethod
+    def __contains__(self, x: str | AgentSetDF) -> bool:
+        """Return ``True`` if a name or object is present.
+
+        Parameters
+        ----------
+        x : str | AgentSetDF
+            A name to test by equality, or an object to test by identity.
+
+        Returns
+        -------
+        bool
+            ``True`` if present, else ``False``.
+        """
+
+    @abstractmethod
+    def __len__(self) -> int:
+        """Return number of agent sets in the collection."""
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[AgentSetDF]:
+        """Iterate over agent set values in insertion order."""

--- a/mesa_frames/abstract/agents.py
+++ b/mesa_frames/abstract/agents.py
@@ -1099,6 +1099,44 @@ class AgentSetDF(AgentContainer, DataFrameMixin):
         return reversed(self._df)
 
     @property
+    @abstractmethod
+    def name(self) -> str | None:
+        """Human-friendly name of this agent set.
+
+        Returns
+        -------
+        str | None
+            The explicit name if set; otherwise None. Names are owned by the
+            agent set itself and are not mutated by `AgentsDF`.
+
+        Notes
+        -----
+        - Names are optional. When not set, accessors like `agents.sets` may
+          display fallback keys derived from the class name for convenience.
+        - Use :meth:`rename` to change the name; direct assignment is not
+          supported.
+        """
+        ...
+
+    @abstractmethod
+    def rename(self, new_name: str) -> None:
+        """Rename this agent set.
+
+        Parameters
+        ----------
+        new_name : str
+            Desired new name. Implementations should ensure uniqueness within
+            the owning model's agents, typically by applying a numeric suffix
+            when a collision occurs (e.g., ``Sheep`` -> ``Sheep_1``).
+
+        Notes
+        -----
+        - Implementations must not mutate other agent sets' names.
+        - This method replaces direct name assignment for clarity and safety.
+        """
+        ...
+
+    @property
     def df(self) -> DataFrame:
         return self._df
 

--- a/mesa_frames/abstract/mixin.py
+++ b/mesa_frames/abstract/mixin.py
@@ -66,6 +66,10 @@ class CopyMixin(ABC):
     _copy_only_reference: list[str] = [
         "_model",
     ]
+    # Attributes listed here are not copied at all and will not be set
+    # on the copied object. Useful for lazily re-creating cyclic or
+    # parent-bound helpers (e.g., accessors) after copy/deepcopy.
+    _skip_copy: list[str] = []
 
     @abstractmethod
     def __init__(self): ...
@@ -113,6 +117,7 @@ class CopyMixin(ABC):
                 for k, v in attributes.items()
                 if k not in self._copy_with_method
                 and k not in self._copy_only_reference
+                and k not in self._skip_copy
                 and k not in skip
             ]
         else:
@@ -121,15 +126,20 @@ class CopyMixin(ABC):
                 for k, v in self.__dict__.items()
                 if k not in self._copy_with_method
                 and k not in self._copy_only_reference
+                and k not in self._skip_copy
                 and k not in skip
             ]
 
         # Copy attributes with a reference only
         for attr in self._copy_only_reference:
+            if attr in self._skip_copy or attr in skip:
+                continue
             setattr(obj, attr, getattr(self, attr))
 
         # Copy attributes with a specified method
         for attr in self._copy_with_method:
+            if attr in self._skip_copy or attr in skip:
+                continue
             attr_obj = getattr(self, attr)
             attr_copy_method, attr_copy_args = self._copy_with_method[attr]
             setattr(obj, attr, getattr(attr_obj, attr_copy_method)(*attr_copy_args))

--- a/mesa_frames/concrete/accessors.py
+++ b/mesa_frames/concrete/accessors.py
@@ -37,15 +37,13 @@ class AgentSetsAccessor(AgentSetsAccessorBase):
                 # No matches - list available agent set types
                 available_types = list(set(type(s).__name__ for s in sets))
                 raise KeyError(f"No agent set of type {getattr(key, '__name__', key)} found. "
-                             f"Available agent set types: {available_types}")
+                              f"Available agent set types: {available_types}")
             elif len(matches) == 1:
                 # Single match - return it directly
                 return matches[0]
             else:
-                # Multiple matches - list all matching agent sets
-                match_names = [s.name for s in matches]
-                raise ValueError(f"Multiple agent sets ({len(matches)}) of type {getattr(key, '__name__', key)} found. "
-                               f"Matching agent sets: {matches}")
+                # Multiple matches - return all matching agent sets as list
+                return matches
         raise TypeError("Key must be int | str | type[AgentSetDF]")
 
     def get(

--- a/mesa_frames/concrete/accessors.py
+++ b/mesa_frames/concrete/accessors.py
@@ -11,7 +11,7 @@ from mesa_frames.abstract.accessors import AgentSetsAccessorBase
 
 
 class AgentSetsAccessor(AgentSetsAccessorBase):
-    def __init__(self, parent: "AgentsDF") -> None:
+    def __init__(self, parent: mesa_frames.concrete.agents.AgentsDF) -> None:
         self._parent = parent
 
     def __getitem__(
@@ -40,11 +40,13 @@ class AgentSetsAccessor(AgentSetsAccessorBase):
     ) -> AgentSetDF | list[AgentSetDF] | Any | None:
         try:
             val = self[key]
-            if isinstance(key, type) and val == [] and default is None:
-                return []
+            # For type keys: if no matches and a default was provided, return the default;
+            # if no default, preserve list shape and return [].
+            if isinstance(key, type) and isinstance(val, list) and len(val) == 0:
+                return [] if default is None else default
             return val
         except (KeyError, IndexError, TypeError):
-            # For type keys, preserve list shape by default
+            # For type keys, preserve list shape by default when default is None
             if isinstance(key, type) and default is None:
                 return []
             return default

--- a/mesa_frames/concrete/accessors.py
+++ b/mesa_frames/concrete/accessors.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Iterable, Iterator, Mapping
 from types import MappingProxyType
 from typing import Any, cast
 
-from types_ import KeyBy
-
+from mesa_frames.types_ import KeyBy
 from mesa_frames.abstract.agents import AgentSetDF
-from mesa_frames.concrete.agents import AgentsDF
+from mesa_frames.abstract.accessors import AgentSetsAccessorBase
 
 
 class AgentSetsAccessor(AgentSetsAccessorBase):
@@ -16,22 +17,22 @@ class AgentSetsAccessor(AgentSetsAccessorBase):
     def __getitem__(
         self, key: int | str | type[AgentSetDF]
     ) -> AgentSetDF | list[AgentSetDF]:
-        p = self._parent
+        sets = self._parent._agentsets
         if isinstance(key, int):
             try:
-                return p._agentsets[key]
+                return sets[key]
             except IndexError as e:
                 raise IndexError(
-                    f"Index {key} out of range for {len(p._agentsets)} agent sets"
+                    f"Index {key} out of range for {len(sets)} agent sets"
                 ) from e
         if isinstance(key, str):
-            for s in p._agentsets:
+            for s in sets:
                 if s.name == key:
                     return s
-            available = [getattr(s, "name", None) for s in p._agentsets]
+            available = [getattr(s, "name", None) for s in sets]
             raise KeyError(f"No agent set named '{key}'. Available: {available}")
         if isinstance(key, type):
-            return [s for s in p._agentsets if isinstance(s, key)]
+            return [s for s in sets if isinstance(s, key)]
         raise TypeError("Key must be int | str | type[AgentSetDF]")
 
     def get(
@@ -103,10 +104,11 @@ class AgentSetsAccessor(AgentSetsAccessorBase):
 
     # ---------- membership & iteration ----------
     def __contains__(self, x: str | AgentSetDF) -> bool:
+        sets = self._parent._agentsets
         if isinstance(x, str):
-            return any(s.name == x for s in self._parent._agentsets)
+            return any(s.name == x for s in sets)
         if isinstance(x, AgentSetDF):
-            return any(s is x for s in self._parent._agentsets)
+            return any(s is x for s in sets)
         return False
 
     def __len__(self) -> int:

--- a/mesa_frames/concrete/accessors.py
+++ b/mesa_frames/concrete/accessors.py
@@ -32,7 +32,20 @@ class AgentSetsAccessor(AgentSetsAccessorBase):
             available = [getattr(s, "name", None) for s in sets]
             raise KeyError(f"No agent set named '{key}'. Available: {available}")
         if isinstance(key, type):
-            return [s for s in sets if isinstance(s, key)]
+            matches = [s for s in sets if isinstance(s, key)]
+            if len(matches) == 0:
+                # No matches - list available agent set types
+                available_types = list(set(type(s).__name__ for s in sets))
+                raise KeyError(f"No agent set of type {getattr(key, '__name__', key)} found. "
+                             f"Available agent set types: {available_types}")
+            elif len(matches) == 1:
+                # Single match - return it directly
+                return matches[0]
+            else:
+                # Multiple matches - list all matching agent sets
+                match_names = [s.name for s in matches]
+                raise ValueError(f"Multiple agent sets ({len(matches)}) of type {getattr(key, '__name__', key)} found. "
+                               f"Matching agent sets: {matches}")
         raise TypeError("Key must be int | str | type[AgentSetDF]")
 
     def get(

--- a/mesa_frames/concrete/accessors.py
+++ b/mesa_frames/concrete/accessors.py
@@ -1,0 +1,116 @@
+from collections import defaultdict
+from collections.abc import Iterable, Iterator, Mapping
+from types import MappingProxyType
+from typing import Any, cast
+
+from types_ import KeyBy
+
+from mesa_frames.abstract.agents import AgentSetDF
+from mesa_frames.concrete.agents import AgentsDF
+
+
+class AgentSetsAccessor(AgentSetsAccessorBase):
+    def __init__(self, parent: "AgentsDF") -> None:
+        self._parent = parent
+
+    def __getitem__(
+        self, key: int | str | type[AgentSetDF]
+    ) -> AgentSetDF | list[AgentSetDF]:
+        p = self._parent
+        if isinstance(key, int):
+            try:
+                return p._agentsets[key]
+            except IndexError as e:
+                raise IndexError(
+                    f"Index {key} out of range for {len(p._agentsets)} agent sets"
+                ) from e
+        if isinstance(key, str):
+            for s in p._agentsets:
+                if s.name == key:
+                    return s
+            available = [getattr(s, "name", None) for s in p._agentsets]
+            raise KeyError(f"No agent set named '{key}'. Available: {available}")
+        if isinstance(key, type):
+            return [s for s in p._agentsets if isinstance(s, key)]
+        raise TypeError("Key must be int | str | type[AgentSetDF]")
+
+    def get(
+        self, key: int | str | type[AgentSetDF], default: Any | None = None
+    ) -> AgentSetDF | list[AgentSetDF] | Any | None:
+        try:
+            val = self[key]
+            if isinstance(key, type) and val == [] and default is None:
+                return []
+            return val
+        except (KeyError, IndexError, TypeError):
+            # For type keys, preserve list shape by default
+            if isinstance(key, type) and default is None:
+                return []
+            return default
+
+    def first(self, t: type[AgentSetDF]) -> AgentSetDF:
+        matches = [s for s in self._parent._agentsets if isinstance(s, t)]
+        if not matches:
+            raise KeyError(f"No agent set of type {getattr(t, '__name__', t)} found.")
+        return matches[0]
+
+    def all(self, t: type[AgentSetDF]) -> list[AgentSetDF]:
+        return [s for s in self._parent._agentsets if isinstance(s, t)]
+
+    def at(self, index: int) -> AgentSetDF:
+        return self[index]  # type: ignore[return-value]
+
+    # ---------- key generation and views ----------
+    def _gen_key(self, aset: AgentSetDF, idx: int, mode: str) -> Any:
+        if mode == "name":
+            return aset.name
+        if mode == "index":
+            return idx
+        if mode == "object":
+            return aset
+        if mode == "type":
+            return type(aset)
+        raise ValueError("key_by must be 'name'|'index'|'object'|'type'")
+
+    def keys(self, *, key_by: KeyBy = "name") -> Iterable[Any]:
+        for i, s in enumerate(self._parent._agentsets):
+            yield self._gen_key(s, i, key_by)
+
+    def items(self, *, key_by: KeyBy = "name") -> Iterable[tuple[Any, AgentSetDF]]:
+        for i, s in enumerate(self._parent._agentsets):
+            yield self._gen_key(s, i, key_by), s
+
+    def values(self) -> Iterable[AgentSetDF]:
+        return iter(self._parent._agentsets)
+
+    def iter(self, *, key_by: KeyBy = "name") -> Iterable[tuple[Any, AgentSetDF]]:
+        return self.items(key_by=key_by)
+
+    def mapping(self, *, key_by: KeyBy = "name") -> dict[Any, AgentSetDF]:
+        return {k: v for k, v in self.items(key_by=key_by)}
+
+    # ---------- read-only snapshots ----------
+    @property
+    def by_name(self) -> Mapping[str, AgentSetDF]:
+        return MappingProxyType({cast(str, s.name): s for s in self._parent._agentsets})
+
+    @property
+    def by_type(self) -> Mapping[type, list[AgentSetDF]]:
+        d: dict[type, list[AgentSetDF]] = defaultdict(list)
+        for s in self._parent._agentsets:
+            d[type(s)].append(s)
+        return MappingProxyType(dict(d))
+
+    # ---------- membership & iteration ----------
+    def __contains__(self, x: str | AgentSetDF) -> bool:
+        if isinstance(x, str):
+            return any(s.name == x for s in self._parent._agentsets)
+        if isinstance(x, AgentSetDF):
+            return any(s is x for s in self._parent._agentsets)
+        return False
+
+    def __len__(self) -> int:
+        return len(self._parent._agentsets)
+
+    def __iter__(self) -> Iterator[AgentSetDF]:
+        return iter(self._parent._agentsets)

--- a/mesa_frames/concrete/accessors.py
+++ b/mesa_frames/concrete/accessors.py
@@ -5,12 +5,12 @@ from collections.abc import Iterable, Iterator, Mapping
 from types import MappingProxyType
 from typing import Any, Literal, cast
 
-from mesa_frames.types_ import KeyBy
+from mesa_frames.abstract.accessors import AbstractAgentSetsAccessor
 from mesa_frames.abstract.agents import AgentSetDF
-from mesa_frames.abstract.accessors import AgentSetsAccessorBase
+from mesa_frames.types_ import KeyBy
 
 
-class AgentSetsAccessor(AgentSetsAccessorBase):
+class AgentSetsAccessor(AbstractAgentSetsAccessor):
     def __init__(self, parent: mesa_frames.concrete.agents.AgentsDF) -> None:
         self._parent = parent
 
@@ -36,8 +36,10 @@ class AgentSetsAccessor(AgentSetsAccessorBase):
             if len(matches) == 0:
                 # No matches - list available agent set types
                 available_types = list(set(type(s).__name__ for s in sets))
-                raise KeyError(f"No agent set of type {getattr(key, '__name__', key)} found. "
-                              f"Available agent set types: {available_types}")
+                raise KeyError(
+                    f"No agent set of type {getattr(key, '__name__', key)} found. "
+                    f"Available agent set types: {available_types}"
+                )
             elif len(matches) == 1:
                 # Single match - return it directly
                 return matches[0]
@@ -118,7 +120,10 @@ class AgentSetsAccessor(AgentSetsAccessorBase):
     # ---------- membership & iteration ----------
     def rename(
         self,
-        target: AgentSetDF | str | dict[AgentSetDF | str, str] | list[tuple[AgentSetDF | str, str]],
+        target: AgentSetDF
+        | str
+        | dict[AgentSetDF | str, str]
+        | list[tuple[AgentSetDF | str, str]],
         new_name: str | None = None,
         *,
         on_conflict: Literal["canonicalize", "raise"] = "canonicalize",
@@ -157,7 +162,9 @@ class AgentSetsAccessor(AgentSetsAccessorBase):
         Batch rename (list):
         >>> agents.sets.rename([("set1", "new_name"), ("set2", "another_name")])
         """
-        return self._parent._rename_set(target, new_name, on_conflict=on_conflict, mode=mode)
+        return self._parent._rename_set(
+            target, new_name, on_conflict=on_conflict, mode=mode
+        )
 
     def __contains__(self, x: str | AgentSetDF) -> bool:
         sets = self._parent._agentsets

--- a/mesa_frames/concrete/agents.py
+++ b/mesa_frames/concrete/agents.py
@@ -177,7 +177,9 @@ class AgentsDF(AgentContainer):
         """
         # Validate target is in this container
         if target not in self._agentsets:
-            raise ValueError(f"AgentSet {target} is not in this container")
+            available_names = [s.name for s in self._agentsets]
+            raise ValueError(f"AgentSet {target} is not in this container. "
+                           f"Available agent sets: {available_names}")
 
         # Check for conflicts with existing names (excluding current target)
         existing_names = {s.name for s in self._agentsets if s is not target}

--- a/mesa_frames/concrete/model.py
+++ b/mesa_frames/concrete/model.py
@@ -112,10 +112,12 @@ class ModelDF:
         AgentSetDF
             The AgentSetDF of the specified type.
         """
-        for agentset in self._agents._agentsets:
-            if isinstance(agentset, agent_type):
-                return agentset
-        raise ValueError(f"No agents of type {agent_type} found in the model.")
+        try:
+            return self.agents.sets[agent_type]
+        except KeyError as e:
+            raise ValueError(
+                f"No agents of type {agent_type} found in the model."
+            ) from e
 
     def reset_randomizer(self, seed: int | Sequence[int] | None) -> None:
         """Reset the model random number generator.
@@ -196,7 +198,7 @@ class ModelDF:
         list[type]
             A list of the different agent types present in the model.
         """
-        return [agent.__class__ for agent in self._agents._agentsets]
+        return [agent.__class__ for agent in self.agents.sets]
 
     @property
     def space(self) -> SpaceDF:

--- a/mesa_frames/types_.py
+++ b/mesa_frames/types_.py
@@ -83,6 +83,9 @@ IdsLike = AgnosticIds | PolarsIdsLike
 ArrayLike = ndarray | Series | Sequence
 Infinity = Annotated[float, IsEqual[math.inf]]  # Only accepts math.inf
 
+# Common option types
+KeyBy = Literal["name", "index", "object", "type"]
+
 ###----- Time ------###
 TimeT = float | int
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1002,18 +1002,6 @@ class Test_AgentsDF:
             )
         )
 
-    def test_agentsets_by_type(self, fix_AgentsDF: AgentsDF):
-        agents = fix_AgentsDF
-
-        result = agents.agentsets_by_type
-        assert isinstance(result, dict)
-        assert isinstance(result[ExampleAgentSetPolars], AgentsDF)
-
-        assert (
-            result[ExampleAgentSetPolars]._agentsets[0].df.rows()
-            == agents._agentsets[1].df.rows()
-        )
-
     def test_inactive_agents(self, fix_AgentsDF: AgentsDF):
         agents = fix_AgentsDF
 

--- a/tests/test_sets_accessor.py
+++ b/tests/test_sets_accessor.py
@@ -1,0 +1,145 @@
+from copy import copy, deepcopy
+
+import pytest
+
+from mesa_frames import AgentsDF, ModelDF
+from tests.test_agentset import ExampleAgentSetPolars, fix1_AgentSetPolars, fix2_AgentSetPolars
+from tests.test_agents import fix_AgentsDF
+
+
+class TestAgentSetsAccessor:
+    def test___getitem__(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        # int
+        assert agents.sets[0] is s1
+        assert agents.sets[1] is s2
+        with pytest.raises(IndexError):
+            _ = agents.sets[2]
+        # str
+        assert agents.sets[s1.name] is s1
+        assert agents.sets[s2.name] is s2
+        with pytest.raises(KeyError):
+            _ = agents.sets["__missing__"]
+        # type → always list
+        lst = agents.sets[ExampleAgentSetPolars]
+        assert isinstance(lst, list)
+        assert s1 in lst and s2 in lst and len(lst) == 2
+
+    def test_get(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        assert agents.sets.get("__missing__") is None
+        assert agents.sets.get(999, default="x") == "x"
+
+        class Temp(ExampleAgentSetPolars):
+            pass
+
+        assert agents.sets.get(Temp) == []
+        assert agents.sets.get(Temp, default=None) == []
+        assert agents.sets.get(Temp, default=["fallback"]) == ["fallback"]
+
+    def test_first(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        assert agents.sets.first(ExampleAgentSetPolars) is agents.sets[0]
+        class Temp(ExampleAgentSetPolars):
+            pass
+        with pytest.raises(KeyError):
+            agents.sets.first(Temp)
+
+    def test_all(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        assert agents.sets.all(ExampleAgentSetPolars) == [agents.sets[0], agents.sets[1]]
+        class Temp(ExampleAgentSetPolars):
+            pass
+        assert agents.sets.all(Temp) == []
+
+    def test_at(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        assert agents.sets.at(0) is agents.sets[0]
+        assert agents.sets.at(1) is agents.sets[1]
+
+    def test_keys(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        assert list(agents.sets.keys(key_by="index")) == [0, 1]
+        assert list(agents.sets.keys(key_by="object")) == [s1, s2]
+        assert list(agents.sets.keys(key_by="name")) == [s1.name, s2.name]
+        assert list(agents.sets.keys(key_by="type")) == [type(s1), type(s2)]
+
+    def test_items(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        assert list(agents.sets.items(key_by="index")) == [(0, s1), (1, s2)]
+        assert list(agents.sets.items(key_by="object")) == [(s1, s1), (s2, s2)]
+
+    def test_values(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        assert list(agents.sets.values()) == [s1, s2]
+
+    def test_iter(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        assert list(agents.sets.iter(key_by="name")) == [(s1.name, s1), (s2.name, s2)]
+
+    def test_mapping(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        by_type_map = agents.sets.mapping(key_by="type")
+        assert list(by_type_map.keys()) == [type(s1)]
+        assert by_type_map[type(s1)] is s2
+
+    def test_by_name(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        name_map = agents.sets.by_name
+        assert name_map[s1.name] is s1
+        assert name_map[s2.name] is s2
+        with pytest.raises(TypeError):
+            name_map["X"] = s1  # type: ignore[index]
+
+    def test_by_type(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        grouped = agents.sets.by_type
+        assert list(grouped.keys()) == [type(s1)]
+        assert grouped[type(s1)] == [s1, s2]
+
+    def test___contains__(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        assert s1.name in agents.sets
+        assert s2.name in agents.sets
+        assert s1 in agents.sets and s2 in agents.sets
+
+    def test___len__(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        assert len(agents.sets) == 2
+
+    def test___iter__(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        assert list(iter(agents.sets)) == [s1, s2]
+
+    def test_copy_and_deepcopy_rebinds_accessor(self, fix_AgentsDF):
+        agents = fix_AgentsDF
+        s1 = agents.sets[0]
+        s2 = agents.sets[1]
+        a2 = copy(agents)
+        acc2 = a2.sets  # lazily created
+        assert acc2._parent is a2
+        assert acc2 is not agents.sets
+        a3 = deepcopy(agents)
+        acc3 = a3.sets  # lazily created
+        assert acc3._parent is a3
+        assert acc3 is not agents.sets and acc3 is not acc2

--- a/uv.lock
+++ b/uv.lock
@@ -1258,6 +1258,7 @@ dev = [
 docs = [
     { name = "autodocsumm" },
     { name = "beartype" },
+    { name = "mesa" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-jupyter" },
@@ -1319,6 +1320,7 @@ dev = [
 docs = [
     { name = "autodocsumm", specifier = ">=0.2.14" },
     { name = "beartype", specifier = ">=0.21.0" },
+    { name = "mesa", specifier = ">=3.2.0" },
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.7" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
     { name = "mkdocs-jupyter", specifier = ">=0.25.1" },


### PR DESCRIPTION
This PR implements the new **`.sets` accessor** on `AgentsDF`, addressing [#146](https://github.com/projectmesa/mesa-frames/issues/146). The goal is to make agent set management more predictable and user-friendly by exposing a dict-like API for lookup and iteration, while keeping `_agentsets` internal. This also sets the stage for #162 (column accessor) and container-level name canonicalization.

Notes:
- Uniqueness of name is only handled at `AgentsDF` level for separation of concerns
- `AgentSetsAccessor` is not copied in copy operation but created from scratch to avoid keeping the `_parent` reference to the original `AgentsDF

